### PR TITLE
Improve error handling

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -44,17 +44,20 @@ exports.execute = function (stream, options, cb) {
       ? 'identity'
       : scriptStrWithPipes).replace(/ \| /g, ',');
     const source = `flow(${scriptStr})($$input$$);`;
-    const script = new vm.Script(source);
-    const context = new vm.createContext(sandbox);
-
+    var result;
+    var shouldHighlight;
     try {
-      const result = script.runInContext(context);
-      const shouldHighlight = options.json || !_.isString(result) 
-      return cb(null, shouldHighlight
-      ? highlight(JSON.stringify(result, null, 2) || '')
-      : result);
+      const script = new vm.Script(source);
+      const context = new vm.createContext(sandbox);
+
+      result = script.runInContext(context);
+      shouldHighlight = options.json || !_.isString(result) 
     } catch (err) {
-      return cb(new Error(`[Invalid Expression] %s ${source}`));
+      return cb(new Error(`[Invalid Expression] %s ${source}\nCaused by ${err}`));
     }
+
+    return cb(null, shouldHighlight
+    ? highlight(JSON.stringify(result, null, 2) || '')
+    : result);
   });
 }


### PR DESCRIPTION
- Catch parsing errors in `vm.Script(source)`
- Catch errors with `vm.createContext(sandbox)`
- Don't catch errors from the callback function `cb`
- Show cause of error in the message, e.g. "Cause by TypeError: ...asdf is not a function" 